### PR TITLE
fork from CF (2.7)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gperftools" %}
-{% set version = "2.7" %}
-{% set sha256 = "3a88b4544315d550c87db5c96775496243fb91aa2cea88d2b845f65823f3d38a" %}
+{% set version = "2.9.1" %}
+{% set sha256 = "484a88279d2fa5753d7e9dea5f86954b64975f20e796a6ffaf2f3426a674a06a" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win]
   missing_dso_whitelist:         # [linux]
     - "*/libpthread.so.*"        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - automake
     - make
     - libtool
-    - {{ pin_compatible('libunwind', max_pin='x.x') }}  # [linux]
+    #- {{ pin_compatible('libunwind', max_pin='x.x') }}  # [linux]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - libunwind  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,12 @@ source:
 build:
   number: 2
   skip: true  # [win]
+  missing_dso_whitelist:         # [linux]
+    - "*/libpthread.so.*"        # [linux]
+    - "*/libm.so.*"              # [linux]
+    - "*/libc.so.*"              # [linux]
+    - "*/ld-linux-x86-64.so.*"   # [linux and x86_64]
+    - "*/ld-linux-aarch64.so.*"  # [linux and aarch64]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,10 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/{{name}}/{{name}}/archive/{{name}}-{{version}}.tar.gz
   sha256: {{ sha256 }}
-  # locking up the s390x prefect build node
-  skip: true  # [s390x]
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: true  # [win or s390x]
   missing_dso_whitelist:         # [linux]
     - "*/libpthread.so.*"        # [linux]
     - "*/libm.so.*"              # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   skip: true  # [win]
 
 requirements:
-  build:
+  host:
     - autoconf
     - automake
     - make
@@ -24,7 +24,6 @@ requirements:
     - {{ pin_compatible('libunwind', max_pin='x.x') }}  # [linux]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
     - libunwind  # [linux]
   run:
     - perl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/{{name}}/{{name}}/archive/{{name}}-{{version}}.tar.gz
   sha256: {{ sha256 }}
+  # locking up the s390x prefect build node
+  skip: true  # [s390x]
 
 build:
   number: 0


### PR DESCRIPTION
abandoned for now because it's no longer necessary.

* [x] upstream repo https://github.com/gperftools/gperftools
* [x] go through [changelog](https://github.com/gperftools/gperftools/releases)
* [x] dev_url, doc_url valid
* [x] check license is accurate